### PR TITLE
Members and Inventories migrations and association set up

### DIFF
--- a/lib/wine_o_inventory_api/inventories/inventory.ex
+++ b/lib/wine_o_inventory_api/inventories/inventory.ex
@@ -1,0 +1,17 @@
+defmodule WineOInventoryApi.Inventories.Inventory do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "inventories" do
+    belongs_to :member, WineOInventoryApi.Users.Member
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(inventory, attrs) do
+    inventory
+    |> cast(attrs, [])
+    |> validate_required([])
+  end
+end

--- a/lib/wine_o_inventory_api/inventories/inventory.ex
+++ b/lib/wine_o_inventory_api/inventories/inventory.ex
@@ -12,6 +12,5 @@ defmodule WineOInventoryApi.Inventories.Inventory do
   def changeset(inventory, attrs) do
     inventory
     |> cast(attrs, [])
-    |> validate_required([])
   end
 end

--- a/lib/wine_o_inventory_api/users/member.ex
+++ b/lib/wine_o_inventory_api/users/member.ex
@@ -1,0 +1,20 @@
+defmodule WineOInventoryApi.Users.Member do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "members" do
+    field :name, :string
+
+    has_one :inventory, WineOInventoryApi.Inventories.Inventory, on_delete: :delete_all
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(member, attrs) do
+    member
+    |> cast(attrs, [:name])
+    |> cast_assoc(:inventory)
+    |> validate_required([:name])
+  end
+end

--- a/priv/repo/migrations/20220207212154_create_members.exs
+++ b/priv/repo/migrations/20220207212154_create_members.exs
@@ -1,0 +1,13 @@
+defmodule WineOInventoryApi.Repo.Migrations.CreateMembers do
+  use Ecto.Migration
+
+  def change do
+    create table(:members) do
+      add :name, :string, null: false
+
+      timestamps()
+    end
+
+    create index(:members, [:name])
+  end
+end

--- a/priv/repo/migrations/20220207214654_create_inventories.exs
+++ b/priv/repo/migrations/20220207214654_create_inventories.exs
@@ -3,7 +3,7 @@ defmodule WineOInventoryApi.Repo.Migrations.CreateInventories do
 
   def change do
     create table(:inventories) do
-      add :member_id, references(:members), null: false
+      add :member_id, references(:members, on_delete: :delete_all), null: false
       timestamps()
     end
   end

--- a/priv/repo/migrations/20220207214654_create_inventories.exs
+++ b/priv/repo/migrations/20220207214654_create_inventories.exs
@@ -1,0 +1,10 @@
+defmodule WineOInventoryApi.Repo.Migrations.CreateInventories do
+  use Ecto.Migration
+
+  def change do
+    create table(:inventories) do
+      add :member_id, references(:members), null: false
+      timestamps()
+    end
+  end
+end


### PR DESCRIPTION
[Link to story](https://trello.com/c/A7HQ6Jvi/137-introducing-relationships-in-wine-o-inventory-app4)

[Link to ERD](https://drive.google.com/file/d/10ZagJaS4j8ZZQ0r7QsUdXpUUtdLneKjC/view?usp=sharing)

Migration Screenshot:
![image](https://user-images.githubusercontent.com/39539557/153009003-b2e799bf-2c54-4f10-b972-7d4a86e5f05e.png)

Highlights:

- Migrations for `Members` and `Inventories` tables
- `has_one` and `belongs_to` association between `Member` and `Inventory` respectively 
- added an `on_delete` option to `Member`'s `has_one` association as well as to the `Inventories` migration file per documentation
- `cast_assoc()` added to `Member`'s `changeset` function so when a `Member` is being created, Ecto can place instructions to create an associated `Inventory` record as well