### PR TITLE
Migrations: added Wineries table, added winery_id to Wines table, and added association

### DIFF
--- a/lib/wine_o_inventory_api/businesses/winery.ex
+++ b/lib/wine_o_inventory_api/businesses/winery.ex
@@ -1,0 +1,22 @@
+defmodule WineOInventoryApi.Businesses.Winery do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "wineries" do
+    field :location, :string
+    field :name, :string
+    field :phone_number, :string
+
+    has_many :wines, WineOInventoryApi.Products.Wine
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(winery, attrs) do
+    winery
+    |> cast(attrs, [:name, :location, :phone_number])
+    |> cast_assoc(:wines)
+    |> validate_required([:name])
+  end
+end

--- a/lib/wine_o_inventory_api/products/wine.ex
+++ b/lib/wine_o_inventory_api/products/wine.ex
@@ -11,6 +11,8 @@ defmodule WineOInventoryApi.Products.Wine do
     many_to_many :stores, WineOInventoryApi.Businesses.Store,
       join_through: "store_wines"
 
+    belongs_to :winery, WineOInventoryApi.Businesses.Winery
+
     timestamps()
   end
 
@@ -19,6 +21,7 @@ defmodule WineOInventoryApi.Products.Wine do
     wine
     |> cast(attrs, [:name, :description, :rating, :quantity])
     |> cast_assoc(:stores)
+    |> cast_assoc(:winery)
     |> validate_inclusion(:rating, 0..5)
     |> validate_required([:name, :description, :rating, :quantity])
   end

--- a/priv/repo/migrations/20220208160027_create_wineries.exs
+++ b/priv/repo/migrations/20220208160027_create_wineries.exs
@@ -1,0 +1,13 @@
+defmodule WineOInventoryApi.Repo.Migrations.CreateWineries do
+  use Ecto.Migration
+
+  def change do
+    create table(:wineries) do
+      add :name, :string, null: false
+      add :location, :string
+      add :phone_number, :string
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20220208162404_wines_add_winery_id_column.exs
+++ b/priv/repo/migrations/20220208162404_wines_add_winery_id_column.exs
@@ -1,0 +1,11 @@
+defmodule WineOInventoryApi.Repo.Migrations.WinesAddWineryIdColumn do
+  use Ecto.Migration
+
+  def change do
+    alter table("wines") do
+      add :winery_id, references(:wineries)
+    end
+
+    create index("wines", [:winery_id])
+  end
+end

--- a/priv/repo/migrations/20220208162404_wines_add_winery_id_column.exs
+++ b/priv/repo/migrations/20220208162404_wines_add_winery_id_column.exs
@@ -3,7 +3,7 @@ defmodule WineOInventoryApi.Repo.Migrations.WinesAddWineryIdColumn do
 
   def change do
     alter table("wines") do
-      add :winery_id, references(:wineries)
+      add :winery_id, references(:wineries, on_delete: :nilify_all)
     end
 
     create index("wines", [:winery_id])


### PR DESCRIPTION
[Link to story](https://trello.com/c/A7HQ6Jvi/137-introducing-relationships-in-wine-o-inventory-app4)

[Link to ERD](https://drive.google.com/file/d/10ZagJaS4j8ZZQ0r7QsUdXpUUtdLneKjC/view?usp=sharing)

Migration Screenshot:
![image](https://user-images.githubusercontent.com/39539557/153041175-e7142496-5548-41c2-ba29-3c18780471c6.png)

Highlights:

- Created a migration to add a `Wineries` table
- Created a migration to add a `winery_id` column to the `Wines` table
- Added a `has_many` and `belongs_to` associations between `Winery` and `Wine` respectively 
- 'cast_assoc()' added to `Wine`'s `changeset` function so when a `Wine` is being created, Ecto can place instructions to create an associated `winery` record as well
- `cast_assoc()` added to the `Winery`'s `changeset` function so when a `Winery` is being created, Ecto can place instructions to create associated `wines` records as well 