### PR TITLE
Migration: Added the on_delete option to store_wines table

### DIFF
--- a/priv/repo/migrations/20220207160946_create_store_wines.exs
+++ b/priv/repo/migrations/20220207160946_create_store_wines.exs
@@ -3,8 +3,8 @@ defmodule WineOInventoryApi.Repo.Migrations.CreateStoreWines do
 
   def change do
     create table(:store_wines, primary_key: false) do
-      add :wine_id, references(:wines, on_delete: :delete_all), null: false
-      add :store_id, references(:stores, on_delete: :delete_all), null: false
+      add :wine_id, references(:wines), null: false
+      add :store_id, references(:stores), null: false
     end
 
     create index(:store_wines, [:wine_id, :store_id])

--- a/priv/repo/migrations/20220207160946_create_store_wines.exs
+++ b/priv/repo/migrations/20220207160946_create_store_wines.exs
@@ -3,8 +3,8 @@ defmodule WineOInventoryApi.Repo.Migrations.CreateStoreWines do
 
   def change do
     create table(:store_wines, primary_key: false) do
-      add :wine_id, references(:wines), null: false
-      add :store_id, references(:stores), null: false
+      add :wine_id, references(:wines, on_delete: :delete_all), null: false
+      add :store_id, references(:stores, on_delete: :delete_all), null: false
     end
 
     create index(:store_wines, [:wine_id, :store_id])

--- a/priv/repo/migrations/20220209155527_store_wines_modify_foreign_keys.exs
+++ b/priv/repo/migrations/20220209155527_store_wines_modify_foreign_keys.exs
@@ -1,0 +1,13 @@
+defmodule WineOInventoryApi.Repo.Migrations.StoreWinesModifyForeignKeys do
+  use Ecto.Migration
+
+  def change do
+    execute "ALTER TABLE store_wines DROP CONSTRAINT store_wines_wine_id_fkey"
+    execute "ALTER TABLE store_wines DROP CONSTRAINT store_wines_store_id_fkey"
+    
+    alter table("store_wines") do
+      modify :wine_id, references(:wines, on_delete: :delete_all), null: false
+      modify :store_id, references(:stores, on_delete: :delete_all), null: false
+    end
+  end
+end


### PR DESCRIPTION
[Link to story](https://trello.com/c/A7HQ6Jvi/137-introducing-relationships-in-wine-o-inventory-app4)

[Link to ERD](https://drive.google.com/file/d/10ZagJaS4j8ZZQ0r7QsUdXpUUtdLneKjC/view?usp=sharing)

Migration Screenshots:
![image](https://user-images.githubusercontent.com/39539557/153075365-23b4a21f-06f9-46c7-9bfe-2df49d48ed86.png)

![image](https://user-images.githubusercontent.com/39539557/153075684-000d1ede-dadc-4d9e-b20e-3cacb7773924.png)

Highlights:

- added the `on_delete` options to the `wine_id` and `store_id` in the join table. 

Updated Migration Screenshots:

![image](https://user-images.githubusercontent.com/39539557/153242433-83a69fc0-3f40-4759-a1a9-ad42c94c0cb6.png)

After removing `on_delete` options from `wine_id` and `store_id`
![image](https://user-images.githubusercontent.com/39539557/153242723-002ea012-9ff4-49e6-8f3e-b22d0fbeb017.png)

![image](https://user-images.githubusercontent.com/39539557/153242789-b5a78b63-820f-464d-87f4-4be945b9c809.png)